### PR TITLE
Rm redundant collection id

### DIFF
--- a/sentinel2/sentinel2-sample.json
+++ b/sentinel2/sentinel2-sample.json
@@ -62,7 +62,6 @@
     "eo:cloud_cover": 88.459539,
     "view:sun_azimuth" : 176.091667178268
   },
-  "collection": "s2-l2a",
   "assets": {
     "metadata": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/metadata.xml",


### PR DESCRIPTION
Collection id was already stated on line 9

https://github.com/stac-utils/stac-examples/blob/c44630613b4300ad9eb9dc4a5c46f6ca05025155/sentinel2/sentinel2-sample.json#L9

Or perhaps the collection should be `"s2-l2a"` in which case we should drop line 9? 🤷 